### PR TITLE
Add Service Account for Pods View

### DIFF
--- a/serviceaccount.yaml
+++ b/serviceaccount.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tomcat-in-the-cloud
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: tomcat-in-the-cloud
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: tomcat-in-the-cloud
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tomcat-in-the-cloud
+subjects:
+- kind: ServiceAccount
+  name: tomcat-in-the-cloud


### PR DESCRIPTION
This service account is handy to enable pods view permissions on Kubernetes based cloud providers.